### PR TITLE
Support of /etc/default/rkhunter

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,8 +1,16 @@
 rkhunter:
+  defaults:
+    cron_daily_run: true
+    cron_db_update: true
+    db_update_email: false
+    report_email: root
+    apt_autogen: true
+    run_check_on_battery: false
   config:
     mail-on-warning: root
     logfile: /var/log/rkhunter.log
     allow_ssh_root_user: without-password
+    allow_ssh_prot_v1: 2
     tmpdir: /var/lib/rkhunter/tmp
     dbdir: /var/lib/rkhunter/db
     scriptdir: /usr/share/rkhunter/scripts

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,8 @@
 rkhunter:
   config:
+    mail-on-warning: root
     logfile: /var/log/rkhunter.log
+    allow_ssh_root_user: without-password
     tmpdir: /var/lib/rkhunter/tmp
     dbdir: /var/lib/rkhunter/db
     scriptdir: /usr/share/rkhunter/scripts

--- a/rkhunter/config.sls
+++ b/rkhunter/config.sls
@@ -3,6 +3,16 @@
 include:
   - rkhunter.install
 
+rkhunter_default_file:
+  file.managed:
+    - name:     {{ rkhunter.default_file }}
+    - user:     root
+    - group:    root
+    - template: jinja
+    - source:   salt://rkhunter/files/rkhunter.default
+    - require:
+      - pkg: rkhunter_package
+
 rkhunter_config_file:
   file.managed:
     - name:     {{ rkhunter.config_file }}

--- a/rkhunter/config.sls
+++ b/rkhunter/config.sls
@@ -10,3 +10,5 @@ rkhunter_config_file:
     - group:    root
     - template: jinja
     - source:   salt://rkhunter/files/rkhunter.conf
+    - require:
+      - pkg: rkhunter_package

--- a/rkhunter/files/rkhunter.default
+++ b/rkhunter/files/rkhunter.default
@@ -1,0 +1,17 @@
+{%- from "rkhunter/map.jinja" import rkhunter with context -%}
+{%- set default_file_config = rkhunter.default_file_config -%}
+{%- set defaults = salt['pillar.get']('rkhunter:defaults', {}) -%}
+{%- set _dummy = default_file_config.update(defaults) -%}
+{%- for key, value in default_file_config.iteritems() -%}
+  {%- if value is number or value is string %}
+{{ key | upper }}={{ value }}
+  {%- elif value is iterable %}
+    {%- if key == 'disable_tests' %}
+{{ key | upper }}='{{ value | join(' ') }}'
+    {%- else %}
+      {%- for subkey in value %}
+{{ key | upper }}={{ subkey }}
+      {%- endfor %}
+    {%- endif %}
+  {%- endif %}
+{%- endfor %}

--- a/rkhunter/map.jinja
+++ b/rkhunter/map.jinja
@@ -3,7 +3,10 @@
     'package': 'rkhunter',
     'config_file': '/etc/rkhunter.conf',
     'default_config': {
+      'mail-on-warning': 'root',
       'logfile': '/var/log/rkhunter.log',
+      'allow_ssh_root_user': 'without-password',
+      'allow_ssh_prot_v1': '2',
       'tmpdir': '/var/lib/rkhunter/tmp',
       'dbdir': '/var/lib/rkhunter/db',
       'scriptdir': '/usr/share/rkhunter/scripts',

--- a/rkhunter/map.jinja
+++ b/rkhunter/map.jinja
@@ -1,7 +1,16 @@
 {% set rkhunter = salt['grains.filter_by']({
   'Debian': {
     'package': 'rkhunter',
+    'default_file': '/etc/default/rkhunter',
     'config_file': '/etc/rkhunter.conf',
+    'default_file_config': {
+      'cron_daily_run': 'true',
+      'cron_db_update': 'true',
+      'db_update_email': 'false',
+      'report_email': 'root',
+      'apt_autogen': 'true',
+      'run_check_on_battery': 'false',
+    },
     'default_config': {
       'mail-on-warning': 'root',
       'logfile': '/var/log/rkhunter.log',


### PR DESCRIPTION
This PR adds the support of the _/etc/default/rkhunter_ file and add a few other settings that could make sense on a recent Debian system, like _allow_ssh_prot_v1_ which allows to ignore the SSH Protocol(s) allowed in _sshd_config_, now that SSHv1 has been discontinued (the Protocol keyword is not available anymore).